### PR TITLE
Add package for handling async routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Let's create a TodoController to showcase how to use this template.
 
 ```TS
 // File: controllers/todo.ts
-import ControllerBase from "@/controllers/base.controller";
+import BaseController from "@/controllers/base.controller";
 import Controller from "@utils/controller.decorator";
 import {Get, Post} from "@utils/route.decorator";
 
@@ -101,7 +101,7 @@ Let's create a `TodoController` class
 
 ```TS
 @Controller()
-export class TodoController extends ControllerBase {
+export class TodoController extends BaseController {
   constructor() {
     super("/users/:id/todos");
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@types/morgan": "^1.9.9",
 		"cors": "^2.8.5",
 		"express": "^4.18.2",
+		"express-async-handler": "^1.2.0",
 		"module-alias": "^2.2.3",
 		"morgan": "^1.10.0"
 	}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import express, { Express } from "express";
 import morgan from "morgan";
 import cors from "cors";
-import ControllerBase from "./controllers/base.controller";
+import BaseController from "./controllers/base.controller";
 
 export default class App {
 	private static instance: App | null = null;
@@ -16,7 +16,7 @@ export default class App {
 		this.port = (process.env.PORT || 5000) as number;
 	}
 
-	injectController(controller: ControllerBase) {
+	injectController(controller: BaseController) {
 		let endpoint = controller.endpoint;
 		if (endpoint.length > 0 && endpoint[0] === "/") {
 			endpoint = endpoint.slice(1);

--- a/src/controllers/base.controller.ts
+++ b/src/controllers/base.controller.ts
@@ -3,14 +3,14 @@ import express from "express";
 /**
  * Controller Base Class
  *
- * The `ControllerBase` class is a base class for implementing controllers in an Express.js application. Controllers
+ * The `BaseController` class is a base class for implementing controllers in an Express.js application. Controllers
  * handle the routing and request handling logic for specific endpoints within the application. This class provides a
  * standardized structure for creating controllers.
  *
  * @property {express.Router} router - An Express Router instance for defining routes and handling HTTP requests.
  * @property {string} endpoint - The base endpoint path for the controller's routes, defaults to "/".
  */
-export default class ControllerBase {
+export default abstract class BaseController {
 	router: express.Router;
 	endpoint: string;
 

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from "express";
 import Controller from "@/utils/controller.decorator";
-import ControllerBase from "./base.controller";
+import BaseController from "./base.controller";
 import { Get, Post } from "@/utils/route.decorator";
 
 @Controller()
-export class UserController extends ControllerBase {
+export class UserController extends BaseController {
 	constructor() {
 		super("/users");
 	}

--- a/src/utils/controller.decorator.ts
+++ b/src/utils/controller.decorator.ts
@@ -1,6 +1,6 @@
 import App from "@/app";
 import ControllerFactory from "./controller.factory";
-import ControllerBase from "@/controllers/base.controller";
+import BaseController from "@/controllers/base.controller";
 
 /**
  * Controller Decorator
@@ -15,7 +15,7 @@ function Controller(...args: any[]): ClassDecorator {
 	return function <T>(target: T) {
 		const app = App.getInstance();
 		const instance = ControllerFactory.getInstance(target, ...args);
-		app.injectController(instance as ControllerBase);
+		app.injectController(instance as BaseController);
 	};
 }
 

--- a/src/utils/controller.factory.ts
+++ b/src/utils/controller.factory.ts
@@ -1,4 +1,4 @@
-import ControllerBase from "@/controllers/base.controller";
+import BaseController from "@/controllers/base.controller";
 
 /**
  * ControllerFactory Class
@@ -9,7 +9,7 @@ import ControllerBase from "@/controllers/base.controller";
  */
 class ControllerFactory {
 	// A map to store instances of controllers, using the class name as the key
-	private static instances: Map<string, ControllerBase> = new Map();
+	private static instances: Map<string, BaseController> = new Map();
 
 	/**
 	 * getInstance Method
@@ -30,7 +30,7 @@ class ControllerFactory {
 			return this.instances.get(name) as T;
 		}
 
-		const instance: ControllerBase = new (controller as any)(...args);
+		const instance: BaseController = new (controller as any)(...args);
 		this.instances.set(name, instance);
 
 		// Log a message indicating that the instance has been created

--- a/src/utils/route.decorator.ts
+++ b/src/utils/route.decorator.ts
@@ -1,5 +1,6 @@
-import ControllerBase from "@/controllers/base.controller";
+import BaseController from "@/controllers/base.controller";
 import ControllerFactory from "./controller.factory";
+import asyncHandler from "express-async-handler";
 import App from "@/app";
 
 enum HttpMethod {
@@ -11,7 +12,7 @@ enum HttpMethod {
 }
 
 function registerRouteWithMethod(
-	instance: ControllerBase,
+	instance: BaseController,
 	originalMethod: any,
 	path: string,
 	method: HttpMethod = HttpMethod.GET,
@@ -23,19 +24,23 @@ function registerRouteWithMethod(
 	}
 	switch (method) {
 		case HttpMethod.GET:
-			instance.router.get(path, ...middlewares, originalMethod);
+			instance.router.get(path, ...middlewares, asyncHandler(originalMethod));
 			break;
 		case HttpMethod.POST:
-			instance.router.post(path, ...middlewares, originalMethod);
+			instance.router.post(path, ...middlewares, asyncHandler(originalMethod));
 			break;
 		case HttpMethod.DELETE:
-			instance.router.delete(path, ...middlewares, originalMethod);
+			instance.router.delete(
+				path,
+				...middlewares,
+				asyncHandler(originalMethod),
+			);
 			break;
 		case HttpMethod.PATCH:
-			instance.router.patch(path, ...middlewares, originalMethod);
+			instance.router.patch(path, ...middlewares, asyncHandler(originalMethod));
 			break;
 		case HttpMethod.PUT:
-			instance.router.put(path, ...middlewares, originalMethod);
+			instance.router.put(path, ...middlewares, asyncHandler(originalMethod));
 			break;
 		default:
 			break;
@@ -61,7 +66,7 @@ function Get(path: string, ...middlewares: any[]) {
 		const instance = ControllerFactory.getInstance(target.constructor);
 
 		registerRouteWithMethod(
-			instance as ControllerBase,
+			instance as BaseController,
 			originalMethod,
 			path,
 			HttpMethod.GET,
@@ -86,7 +91,7 @@ function Delete(path: string, ...middlewares: any[]) {
 		const instance = ControllerFactory.getInstance(target.constructor);
 
 		registerRouteWithMethod(
-			instance as ControllerBase,
+			instance as BaseController,
 			originalMethod,
 			path,
 			HttpMethod.DELETE,
@@ -111,7 +116,7 @@ function Put(path: string, ...middlewares: any[]) {
 		const instance = ControllerFactory.getInstance(target.constructor);
 
 		registerRouteWithMethod(
-			instance as ControllerBase,
+			instance as BaseController,
 			originalMethod,
 			path,
 			HttpMethod.PUT,
@@ -136,7 +141,7 @@ function Post(path: string, ...middlewares: any[]) {
 		const instance = ControllerFactory.getInstance(target.constructor);
 
 		registerRouteWithMethod(
-			instance as ControllerBase,
+			instance as BaseController,
 			originalMethod,
 			path,
 			HttpMethod.POST,
@@ -161,7 +166,7 @@ function Patch(path: string, ...middlewares: any[]) {
 		const instance = ControllerFactory.getInstance(target.constructor);
 
 		registerRouteWithMethod(
-			instance as ControllerBase,
+			instance as BaseController,
 			originalMethod,
 			path,
 			HttpMethod.PATCH,

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,6 +228,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
+express-async-handler@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/express-async-handler/-/express-async-handler-1.2.0.tgz#ffc9896061d90f8d2e71a2d2b8668db5b0934391"
+  integrity sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w==
+
 express@^4.18.2:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"


### PR DESCRIPTION
This commit adds the `express-async-handler` package to handle asynchronous routes more gracefully. The `asyncHandler` utility is integrated into the route decorators, ensuring that asynchronous errors are properly caught and passed to Express's error-handling middleware.

Changes made:
- Added "express-async-handler" as a dependency in package.json
- Rename `ControllerBase` to `BaseController`
- Updated BaseController to be abstract
- Updated route.decorator to use `asyncHandler` for route methods

Fixes: #2 